### PR TITLE
generalize for metaphlan 4 output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ qiime sapienns humann-genefamily --i-genefamily-table humann-genefamilies-2.qza 
 
 ## Usage: MetaPhlAn 3
 
-There may be relevant changes to the file formats used here between versions of MetaPhlAn, though those changes may not be relevant to the _Merged Abundance Table_ [(source)](https://forum.biobakery.org/t/human-and-metaphlan-file-formats/4024/3?u=gregcaporaso). This functionality was developed for the MetaPhlAn format that contains exactly two columns (`clade_name` and `NCBI_tax_id`) before the sample abundance columns. I recommend looking at the column headers for the first three columns in your input file before attempting to use this code. The file should look something like:
+There may be relevant changes to the file formats used here between versions of MetaPhlAn, though those changes may not be relevant to the _Merged Abundance Table_ [(source)](https://forum.biobakery.org/t/human-and-metaphlan-file-formats/4024/3?u=gregcaporaso). This functionality was developed for the MetaPhlAn format that contains exactly two columns (`clade_name` and `NCBI_tax_id`) before the sample abundance columns, but should also work if the `NCBI_tax_id` is not present (as is the case in MetaPhlAn 4 output). I recommend looking at the column headers for the first three columns in your input file before attempting to use this code. The file should look something like:
 
 ```
 $ head -5 metaphlan-merged-abundance.tsv
@@ -87,6 +87,17 @@ clade_name	NCBI_tax_id	sample1	sample_2
 k__Archaea	2157	9.75907	0.02352
 k__Archaea|p__Euryarchaeota	2157|28890	9.75907	0.02352
 k__Archaea|p__Euryarchaeota|c__Methanobacteria	2157|28890|183925	9.75907	0.02352
+```
+
+or
+
+```
+$ head -5 metaphlan-merged-abundance.tsv
+#mpa_vJan21_CHOCOPhlAnSGB_202103
+clade_name	sample1	sample_2
+k__Archaea	9.75907	0.02352
+k__Archaea|p__Euryarchaeota	9.75907	0.02352
+k__Archaea|p__Euryarchaeota|c__Methanobacteria	9.75907	0.02352
 ```
 
 q2-sapienns _should_ fail if you try to import data in a format different than the one it's expecting, but I can't be sure that format validation will work in all cases. It won't hurt to look at your data before using it with q2-sapienns.

--- a/q2_sapienns/_metaphlan.py
+++ b/q2_sapienns/_metaphlan.py
@@ -13,10 +13,12 @@ def metaphlan_taxon(
         stratified_table: pd.DataFrame, level: int)\
         -> (pd.DataFrame, pd.DataFrame):
 
+    stratified_table = stratified_table.reset_index()
+
     # Add a column indicating the number of levels contained in each
     # feature id.
     stratified_table['n levels'] = stratified_table.apply(
-        lambda x: len(x['NCBI_tax_id'].split('|')), axis=1)
+        lambda x: len(x['feature-id'].split('|')), axis=1)
 
     # Drop features where number of levels is not equal to what was requested
     # by the user to "de-stratify" the table.
@@ -26,17 +28,14 @@ def metaphlan_taxon(
                          'levels.' % level)
 
     # Generate the taxonomy result
-    taxonomy = table['NCBI_tax_id']
-    taxonomy = taxonomy.reset_index()
+    taxonomy = table['feature-id'].to_frame()
     taxonomy['Taxon'] = taxonomy.apply(
         lambda x: x['feature-id'].replace('|', '; '), axis=1)
-    taxonomy = taxonomy.drop('feature-id', axis=1)
-    taxonomy = taxonomy.set_index('NCBI_tax_id')
+    taxonomy = taxonomy.set_index('feature-id')
     taxonomy.index.name = 'Feature ID'
 
-    table = table.reset_index()
-    table = table.drop(['feature-id', 'n levels'], axis=1)
-    table = table.set_index('NCBI_tax_id')
+    table = table.drop(['NCBI_tax_id', 'n levels'], errors='ignore', axis=1)
+    table = table.set_index('feature-id')
     table = table.T
     table.index.name = 'sample-id'
 

--- a/q2_sapienns/tests/data/metaphlan-merged-abundance-6.tsv
+++ b/q2_sapienns/tests/data/metaphlan-merged-abundance-6.tsv
@@ -1,0 +1,22 @@
+#mpa_v30_CHOCOPhlAn_201901
+clade_name	sample1	sample_2
+k__Archaea	9.75907	0.02352
+k__Archaea|p__Euryarchaeota	9.75907	0.02352
+k__Archaea|p__Euryarchaeota|c__Methanobacteria	9.75907	0.02352
+k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales	9.75907	0.02352
+k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales|f__Methanobacteriaceae	9.75907	0.02352
+k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales|f__Methanobacteriaceae|g__Methanobrevibacter	9.75907	0.02352
+k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales|f__Methanobacteriaceae|g__Methanobrevibacter|s__Methanobrevibacter_smithii	9.75907	0.02352
+k__Bacteria	90.24093	99.97648
+k__Bacteria|p__Actinobacteria	90.24093	99.97648
+k__Bacteria|p__Actinobacteria|c__Actinobacteria	90.24093	99.97648
+k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales	90.24093	99.97648
+k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae	90.24093	99.97648
+k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinobaculum	45.0	10.97648
+k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinobaculum|s__Actinobaculum_sp_oral_taxon_183	45.0	10.97648
+k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces	45.24093	89
+k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_graevenitzii	5.0	0.0
+k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_naeslundii	1.24093	0.0
+k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_odontolyticus	25.0	0.0
+k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_oris	10.0	9.0
+k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_sp_HMSC035G02	4.0	80.0

--- a/q2_sapienns/tests/test_metaphlan.py
+++ b/q2_sapienns/tests/test_metaphlan.py
@@ -40,8 +40,8 @@ class MetaphlanTaxonTests(TestPluginBase):
                          ['sample1', 'sample_2'])
         self.assertEqual(
             list(obs_table.columns),
-            ['2157',
-             '2'])
+            ['k__Archaea',
+             'k__Bacteria'])
 
         self.assertEqual(list(obs_table.T['sample1']),
                          [9.75907, 90.24093])
@@ -55,8 +55,8 @@ class MetaphlanTaxonTests(TestPluginBase):
         self.assertEqual(list(obs_tax.columns), ['Taxon'])
         self.assertEqual(
             list(obs_tax.index),
-            ['2157',
-             '2'])
+            ['k__Archaea',
+             'k__Bacteria'])
 
         self.assertEqual(
             list(obs_tax['Taxon']),
@@ -77,13 +77,13 @@ class MetaphlanTaxonTests(TestPluginBase):
                          ['sample1', 'sample_2'])
         self.assertEqual(
             list(obs_table.columns),
-            ['2157|28890|183925|2158|2159|2172|2173',
-             '2|201174|1760|2037|2049|76833|712888',
-             '2|201174|1760|2037|2049|1654|55565',
-             '2|201174|1760|2037|2049|1654|1655',
-             '2|201174|1760|2037|2049|1654|1660',
-             '2|201174|1760|2037|2049|1654|544580',
-             '2|201174|1760|2037|2049|1654|1739406'])
+            ['k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales|f__Methanobacteriaceae|g__Methanobrevibacter|s__Methanobrevibacter_smithii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinobaculum|s__Actinobaculum_sp_oral_taxon_183',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_graevenitzii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_naeslundii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_odontolyticus',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_oris',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_sp_HMSC035G02'])  # noqa: E501
 
         self.assertEqual(list(obs_table.T['sample1']),
                          [9.75907, 45.0, 5.0, 1.24093, 25.0, 10.0, 4.0])
@@ -97,13 +97,66 @@ class MetaphlanTaxonTests(TestPluginBase):
         self.assertEqual(list(obs_tax.columns), ['Taxon'])
         self.assertEqual(
             list(obs_tax.index),
-            ['2157|28890|183925|2158|2159|2172|2173',
-             '2|201174|1760|2037|2049|76833|712888',
-             '2|201174|1760|2037|2049|1654|55565',
-             '2|201174|1760|2037|2049|1654|1655',
-             '2|201174|1760|2037|2049|1654|1660',
-             '2|201174|1760|2037|2049|1654|544580',
-             '2|201174|1760|2037|2049|1654|1739406'])
+            ['k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales|f__Methanobacteriaceae|g__Methanobrevibacter|s__Methanobrevibacter_smithii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinobaculum|s__Actinobaculum_sp_oral_taxon_183',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_graevenitzii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_naeslundii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_odontolyticus',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_oris',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_sp_HMSC035G02'])  # noqa: E501
+
+        self.assertEqual(
+            list(obs_tax['Taxon']),
+            ['k__Archaea; p__Euryarchaeota; c__Methanobacteria; o__Methanobacteriales; f__Methanobacteriaceae; g__Methanobrevibacter; s__Methanobrevibacter_smithii',  # noqa: E501
+             'k__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Actinomycetales; f__Actinomycetaceae; g__Actinobaculum; s__Actinobaculum_sp_oral_taxon_183',  # noqa: E501
+             'k__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Actinomycetales; f__Actinomycetaceae; g__Actinomyces; s__Actinomyces_graevenitzii',  # noqa: E501
+             'k__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Actinomycetales; f__Actinomycetaceae; g__Actinomyces; s__Actinomyces_naeslundii',  # noqa: E501
+             'k__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Actinomycetales; f__Actinomycetaceae; g__Actinomyces; s__Actinomyces_odontolyticus',  # noqa: E501
+             'k__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Actinomycetales; f__Actinomycetaceae; g__Actinomyces; s__Actinomyces_oris',  # noqa: E501
+             'k__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Actinomycetales; f__Actinomycetaceae; g__Actinomyces; s__Actinomyces_sp_HMSC035G02'])  # noqa: E501
+
+
+    def test_metaphlan_taxon_level_7_no_tax_id(self):
+        _, input_table_df = self.transform_format(
+            MetaphlanMergedAbundanceFormat, pd.DataFrame,
+            'metaphlan-merged-abundance-6.tsv')
+
+        obs_table, obs_tax = metaphlan_taxon(input_table_df, level=7)
+
+        # Assess resulting tables
+        self.assertEqual(obs_table.index.name, 'sample-id')
+        self.assertEqual(obs_table.shape, (2, 7))
+        self.assertEqual(list(obs_table.index),
+                         ['sample1', 'sample_2'])
+        self.assertEqual(
+            list(obs_table.columns),
+            ['k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales|f__Methanobacteriaceae|g__Methanobrevibacter|s__Methanobrevibacter_smithii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinobaculum|s__Actinobaculum_sp_oral_taxon_183',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_graevenitzii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_naeslundii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_odontolyticus',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_oris',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_sp_HMSC035G02'])  # noqa: E501
+
+        self.assertEqual(list(obs_table.T['sample1']),
+                         [9.75907, 45.0, 5.0, 1.24093, 25.0, 10.0, 4.0])
+
+        self.assertEqual(list(obs_table.T['sample_2']),
+                         [0.02352, 10.97648, 0.0, 0.0, 0.0, 9.0, 80.0])
+
+        # Assess resulting feature metadata
+        self.assertEqual(obs_tax.index.name, 'Feature ID')
+        self.assertEqual(obs_tax.shape, (7, 1))
+        self.assertEqual(list(obs_tax.columns), ['Taxon'])
+        self.assertEqual(
+            list(obs_tax.index),
+            ['k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales|f__Methanobacteriaceae|g__Methanobrevibacter|s__Methanobrevibacter_smithii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinobaculum|s__Actinobaculum_sp_oral_taxon_183',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_graevenitzii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_naeslundii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_odontolyticus',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_oris',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_sp_HMSC035G02'])  # noqa: E501
 
         self.assertEqual(
             list(obs_tax['Taxon']),


### PR DESCRIPTION
MetaPhlAn 4 output does not include the `NCBI_tax_id` column, so that is now optional here.