### PR TITLE
add frequency action

### DIFF
--- a/q2_sapienns/_metaphlan.py
+++ b/q2_sapienns/_metaphlan.py
@@ -40,3 +40,11 @@ def metaphlan_taxon(
     table.index.name = 'sample-id'
 
     return table, taxonomy
+
+
+def frequency(table: pd.DataFrame, target_freq: int = 100000) -> pd.DataFrame:
+    target_freq /= 100
+    result = table * target_freq
+    result = result.round(0)
+    result = result.astype(int)
+    return result

--- a/q2_sapienns/plugin_setup.py
+++ b/q2_sapienns/plugin_setup.py
@@ -13,7 +13,7 @@ from q2_types.feature_data import FeatureData, Taxonomy
 
 import q2_sapienns
 from ._humann import humann_pathway, humann_genefamily
-from ._metaphlan import metaphlan_taxon
+from ._metaphlan import metaphlan_taxon, frequency
 
 import pandas as pd
 
@@ -200,6 +200,26 @@ plugin.methods.register_function(
         citations['bioBakery3']]
 )
 
+plugin.methods.register_function(
+    function=frequency,
+    inputs={'table': FeatureTable[RelativeFrequency]},
+    parameters={'target_freq': Int % Range(1, None)},
+    outputs=[('output_table', FeatureTable[Frequency])],
+    input_descriptions={
+        'table': ('A relative frequency feature table.'),
+    },
+    parameter_descriptions={
+        'target_freq': ('The target per sample total frequency.')
+    },
+    output_descriptions={
+        'output_table': 'A frequency feature table.'},
+    name='Convert relative frequencies to frequencies.',
+    description=('Convert relative frequencies to frequencies by multipling '
+                 'each value by `target_freq` and then rounding to whole '
+                 'numbers. Because rounding is taking place, the total '
+                 'frequency per sample may not be exactly `target_freq`.'),
+    citations=[]
+)
 
 plugin.methods.register_function(
     function=humann_pathway,

--- a/q2_sapienns/tests/test_metaphlan.py
+++ b/q2_sapienns/tests/test_metaphlan.py
@@ -11,7 +11,7 @@ import pandas as pd
 from qiime2.plugin.testing import TestPluginBase
 
 from q2_sapienns import MetaphlanMergedAbundanceFormat
-from q2_sapienns._metaphlan import metaphlan_taxon
+from q2_sapienns._metaphlan import metaphlan_taxon, frequency
 
 
 class MetaphlanTaxonTests(TestPluginBase):
@@ -115,7 +115,6 @@ class MetaphlanTaxonTests(TestPluginBase):
              'k__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Actinomycetales; f__Actinomycetaceae; g__Actinomyces; s__Actinomyces_oris',  # noqa: E501
              'k__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Actinomycetales; f__Actinomycetaceae; g__Actinomyces; s__Actinomyces_sp_HMSC035G02'])  # noqa: E501
 
-
     def test_metaphlan_taxon_level_7_no_tax_id(self):
         _, input_table_df = self.transform_format(
             MetaphlanMergedAbundanceFormat, pd.DataFrame,
@@ -167,3 +166,61 @@ class MetaphlanTaxonTests(TestPluginBase):
              'k__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Actinomycetales; f__Actinomycetaceae; g__Actinomyces; s__Actinomyces_odontolyticus',  # noqa: E501
              'k__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Actinomycetales; f__Actinomycetaceae; g__Actinomyces; s__Actinomyces_oris',  # noqa: E501
              'k__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Actinomycetales; f__Actinomycetaceae; g__Actinomyces; s__Actinomyces_sp_HMSC035G02'])  # noqa: E501
+
+    def test_frequency_100000(self):
+        _, input_table_df = self.transform_format(
+            MetaphlanMergedAbundanceFormat, pd.DataFrame,
+            'metaphlan-merged-abundance-1.tsv')
+
+        obs_rf_table, _ = metaphlan_taxon(input_table_df, level=7)
+        obs_f_table = frequency(obs_rf_table)
+
+        # Assess resulting tables
+        self.assertEqual(obs_f_table.index.name, 'sample-id')
+        self.assertEqual(obs_f_table.shape, (2, 7))
+        self.assertEqual(list(obs_f_table.index),
+                         ['sample1', 'sample_2'])
+        self.assertEqual(
+            list(obs_f_table.columns),
+            ['k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales|f__Methanobacteriaceae|g__Methanobrevibacter|s__Methanobrevibacter_smithii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinobaculum|s__Actinobaculum_sp_oral_taxon_183',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_graevenitzii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_naeslundii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_odontolyticus',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_oris',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_sp_HMSC035G02'])  # noqa: E501
+
+        self.assertEqual(list(obs_f_table.T['sample1']),
+                         [9759, 45000, 5000, 1241, 25000, 10000, 4000])
+
+        self.assertEqual(list(obs_f_table.T['sample_2']),
+                         [24, 10976, 0, 0, 0, 9000, 80000])
+
+    def test_frequency_1(self):
+        _, input_table_df = self.transform_format(
+            MetaphlanMergedAbundanceFormat, pd.DataFrame,
+            'metaphlan-merged-abundance-1.tsv')
+
+        obs_rf_table, _ = metaphlan_taxon(input_table_df, level=7)
+        obs_f_table = frequency(obs_rf_table, 1)
+
+        # Assess resulting tables
+        self.assertEqual(obs_f_table.index.name, 'sample-id')
+        self.assertEqual(obs_f_table.shape, (2, 7))
+        self.assertEqual(list(obs_f_table.index),
+                         ['sample1', 'sample_2'])
+        self.assertEqual(
+            list(obs_f_table.columns),
+            ['k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales|f__Methanobacteriaceae|g__Methanobrevibacter|s__Methanobrevibacter_smithii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinobaculum|s__Actinobaculum_sp_oral_taxon_183',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_graevenitzii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_naeslundii',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_odontolyticus',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_oris',  # noqa: E501
+             'k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales|f__Actinomycetaceae|g__Actinomyces|s__Actinomyces_sp_HMSC035G02'])  # noqa: E501
+
+        self.assertEqual(list(obs_f_table.T['sample1']),
+                         [0, 0, 0, 0, 0, 0, 0])
+
+        self.assertEqual(list(obs_f_table.T['sample_2']),
+                         [0, 0, 0, 0, 0, 0, 1])


### PR DESCRIPTION
This action is intended for use with metaphlan tables to generate FeatureTable[Frequency] artifacts from FeatureTable[RelativeFrequency]. To do this, it multiples by a user-supplied value (default=100,000). This enables easier use with existing QIIME 2 functionality. 